### PR TITLE
[Feature] added support to set template engine configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ import { MailerModule } from '@nest-modules/mailer';
       },
       templateDir: './src/common/email-templates'
       templateOptions: {
-        engine: 'PUG'
+        engine: 'PUG',
+        engineConfig: {
+          doctype: 'html',
+          debug: true
+        }
       }
     }),
   ],
@@ -45,6 +49,8 @@ The `forRoot()` method accepts a configuration JSON object with the following at
 **templateDir** is the path to directory where you have put your templates; the default value is `/public/templates` if not specified.
 
 **templateOptions.engine** is the template engine used for rendering html. Accepts PUG (default) or HANDLEBARS (case-insensitive).
+
+**templateOptions.engineConfig** is an options object used as parameter in template engine `compile/render` function. See more details and avaliable options in [`pug`](https://pugjs.org/api/reference.html) or [`handlebars`](https://handlebarsjs.com/reference.html) API reference.
 
 **templateOptions.precompiledTemplates** is a hash of `templateName: (context) => htmlString`. Currently only used in `handlebars` engine, to optimize dynamic rendering.
 
@@ -124,7 +130,7 @@ MailerModule.forRootAsync({
 })
 ```
 
-Above construction will instantiate MailerConfigService inside MailerModule and will leverage it to create options object. The MailerConfigService has to implement MailerOptionsFactory interface. 
+Above construction will instantiate MailerConfigService inside MailerModule and will leverage it to create options object. The MailerConfigService has to implement MailerOptionsFactory interface.
 
 ```javascript
 @Injectable()

--- a/lib/interfaces/mailer-options.interface.ts
+++ b/lib/interfaces/mailer-options.interface.ts
@@ -10,6 +10,9 @@ export interface MailerModuleOptions {
 export interface TemplateEngineOptions {
   engine?: string;
   engineAdapter?: Function;
+  engineConfig?: {
+    [optionName: string]: string
+  }
   precompiledTemplates?: {
     [templateName: string]: (context: any) => any;
   };

--- a/lib/mailer.utils.ts
+++ b/lib/mailer.utils.ts
@@ -17,3 +17,11 @@ export function ConfigRead(config: any) {
     return {};
   }
 }
+
+export function getProperty(target: object, propertyPath: Array<string>, defaultValue = null) {
+  return propertyPath.reduce(
+    (currentPath, currentProperty) => (currentPath && currentPath[currentProperty])
+      ? currentPath[currentProperty]
+      : defaultValue
+  , target);
+}


### PR DESCRIPTION
This PR add suport to set configurations to be passed for template engine.

Suppose the following config file:

```javascript
//mailerconfig.ts
{
  ...
  templateOptions: {
    engine: 'pug',
    engineConfig: {
      basedir: `${process.cwd()}/src/views/email`
      doctype: 'html',
      debug: true
    }
  }
}
```

The `engineConfig` option is passed as parameter to pug `renderFile` function. Handlebars have the same behavior. With this, the `mailer` library becomes more compatible with used view engines.