### PR TITLE
Move typescript to devDependencies to reduce production package size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1426,7 +1426,8 @@
     "typescript": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
   },
   "homepage": "https://github.com/nest-modules/mailer#readme",
   "dependencies": {
-    "@nestjs/common": "^5.7.2",
-    "@nestjs/core": "^5.7.2",
     "handlebars": "^4.1.0",
     "lodash": "^4.17.11",
     "nodemailer": "^4.7.0",
@@ -45,5 +43,9 @@
     "@types/pug": "^2.0.4",
     "reflect-metadata": "^0.1.12",
     "typescript": "^2.8.1"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^5.7.2",
+    "@nestjs/core": "^5.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
     "lodash": "^4.17.11",
     "nodemailer": "^4.7.0",
     "pug": "^2.0.3",
-    "rxjs": "^5.5.6",
-    "typescript": "^2.8.1"
+    "rxjs": "^5.5.6"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.120",
     "@types/nodemailer": "^4.6.5",
     "@types/pug": "^2.0.4",
-    "reflect-metadata": "^0.1.12"
+    "reflect-metadata": "^0.1.12",
+    "typescript": "^2.8.1"
   }
 }


### PR DESCRIPTION
As title, I see your package declare typescript as a dependency, which can cause unnecessary waste on production package size of depended app. This PR just move it to `devDependencies`.

Thanks,