### PR TITLE
fix for Module forRoot method for nestjs v6

### DIFF
--- a/lib/mailer.module.ts
+++ b/lib/mailer.module.ts
@@ -13,7 +13,7 @@ export class MailerModule {
   public static forRoot(options?: MailerOptions): DynamicModule {
     return {
       module: MailerModule,
-      modules: [
+      imports: [
         /** Modules **/
         MailerCoreModule.forRoot(options),
       ],


### PR DESCRIPTION
Did some changes for being able to use module after migration to Nestjs v6. Think that dependencies should be updated also.