### PR TITLE
Use type Provider instead of CustomValue

### DIFF
--- a/lib/mailer-core.module.ts
+++ b/lib/mailer-core.module.ts
@@ -1,5 +1,4 @@
 /** Dependencies **/
-import { CustomValue } from '@nestjs/core/injector/module';
 import { DynamicModule, Module, Global, Provider } from '@nestjs/common';
 
 /** Constants **/
@@ -17,7 +16,7 @@ import { MailerService } from './mailer.service';
 @Module({})
 export class MailerCoreModule {
   public static forRoot(options: MailerOptions): DynamicModule {
-    const MailerOptionsProvider: CustomValue = {
+    const MailerOptionsProvider: Provider = {
       name: MAILER_OPTIONS,
       provide: MAILER_OPTIONS,
       useValue: options,


### PR DESCRIPTION
Makes it work with NestJS v3.0.5 (minimum required) and v3.7.1 (latest)

Type CustomValue was removed in `@nestjs/nest-core@v6.3.0` (https://github.com/nestjs/nest/commit/8664505d823f6a1158a5d2a6a0964d90de5c7b22)