### PR TITLE
Allow all transport types and options

### DIFF
--- a/lib/interfaces/mailer-options.interface.ts
+++ b/lib/interfaces/mailer-options.interface.ts
@@ -1,10 +1,35 @@
 /** Interfaces **/
+import { Transport, TransportOptions } from 'nodemailer';
 import * as SMTPTransport from 'nodemailer/lib/smtp-transport';
+import * as SMTPPool from 'nodemailer/lib/smtp-pool';
+import * as SendmailTransport from 'nodemailer/lib/sendmail-transport';
+import * as StreamTransport from 'nodemailer/lib/stream-transport';
+import * as JSONTransport from 'nodemailer/lib/json-transport';
+import * as SESTransport from 'nodemailer/lib/ses-transport';
+
 import { TemplateAdapter } from './template-adapter.interface';
 
+type Options = SMTPTransport.Options
+  | SMTPPool.Options
+  | SendmailTransport.Options
+  | StreamTransport.Options
+  | JSONTransport.Options
+  | SESTransport.Options
+  | TransportOptions;
+
+type TransportType = Options
+  | SMTPTransport
+  | SMTPPool
+  | SendmailTransport
+  | StreamTransport
+  | JSONTransport
+  | SESTransport
+  | Transport
+  | string;
+
 export interface MailerOptions {
-  defaults?: SMTPTransport.Options;
-  transport?: SMTPTransport | SMTPTransport.Options | string;
+  defaults?: Options;
+  transport?: TransportType;
   template?: {
     dir?: string;
     adapter?: TemplateAdapter;


### PR DESCRIPTION
Types of `MailerOptions.{default,transport}` properties match accepted types of `nodemailer.createTransport()`, `default` and `transport` parameters.

Resolves #38  and #41 