### PR TITLE
Revert changes made in v1.1.3 and rename ISendMailOptions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,7 +9,7 @@ export { HandlebarsAdapter } from './adapters/handlebars.adapter';
 export { MailerOptions } from './interfaces/mailer-options.interface';
 export { TemplateAdapter } from './interfaces/template-adapter.interface';
 export { MailerOptionsFactory } from './interfaces/mailer-options-factory.interface';
-export { ISendMailOptions } from './interfaces/send-mail-options.interface';
+export { SendMailOptions, ISendMailOptions } from './interfaces/send-mail-options.interface';
 
 /** Services **/
 export { MailerService } from './mailer.service';

--- a/lib/interfaces/send-mail-options.interface.ts
+++ b/lib/interfaces/send-mail-options.interface.ts
@@ -1,11 +1,9 @@
-import { SendMailOptions } from 'nodemailer';
+import { SendMailOptions as BaseMailOptions } from 'nodemailer';
 
-export interface ISendMailOptions extends SendMailOptions {
-  to?: string;
-  from?: string;
-  subject?: string;
-  text?: string;
-  html?: string;
-  template?: string,
-  context?: { [name: string]: any; }
+export interface SendMailOptions extends BaseMailOptions {
+  template?: string;
+  context?: { [name: string]: any };
 }
+
+/* @deprecated defined to maintain compatibility with v1.1.{2,3}, use SendMailOptions instead  */
+export type ISendMailOptions = SendMailOptions;

--- a/lib/mailer.service.ts
+++ b/lib/mailer.service.ts
@@ -9,7 +9,7 @@ import { MAILER_OPTIONS } from './constants/mailer-options.constant';
 /** Interfaces **/
 import { MailerOptions } from './interfaces/mailer-options.interface';
 import { TemplateAdapter } from './interfaces/template-adapter.interface';
-import { ISendMailOptions } from './interfaces/send-mail-options.interface';
+import { SendMailOptions } from './interfaces/send-mail-options.interface';
 
 @Injectable()
 export class MailerService {
@@ -37,7 +37,7 @@ export class MailerService {
     }
   }
 
-  public async sendMail(sendMailOptions: ISendMailOptions): Promise<SentMessageInfo> {
+  public async sendMail(sendMailOptions: SendMailOptions): Promise<SentMessageInfo> {
     return await this.transporter.sendMail(sendMailOptions);
   }
 }


### PR DESCRIPTION
SendMailOptions extends nodemailer.SendMailOptions (alias of nodemailer.Mail.Options[1]) so it inherits all properties defined there.

Addresses issue #33 and #34

1. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/nodemailer/lib/mailer/index.d.ts#L96