### PR TITLE
Add types definition file to root folder

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs-modules/mailer",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "NestJS - a mailer module (@mailer)",
   "author": "Nest Modules TM",
   "private": false,


### PR DESCRIPTION
Adding definition types on root folder. Solves #79 https://github.com/nest-modules/mailer/issues/79