### PR TITLE
added bcc to ISendMailOptions

### DIFF
--- a/lib/interfaces/send-mail-options.interface.ts
+++ b/lib/interfaces/send-mail-options.interface.ts
@@ -17,6 +17,7 @@ export interface AttachmentLikeObject {
 export interface ISendMailOptions extends SendMailOptions {
   to?: string | Address | Array<string | Address>;
   cc?: string | Address | Array<string | Address>;
+  bcc?: string | Address | Array<string | Address>;
   replyTo?: string | Address;
   inReplyTo?: string | Address;
   from?: string | Address;


### PR DESCRIPTION
I needed to be able to add BCC values to the email. In nodemailer this is possible, in nest mailer this is not. 
So I added this in the interface, so it gives the possibility to add BCC in the email.