### PR TITLE
Update EJS adapter to support include ( partials )

### DIFF
--- a/lib/adapters/ejs.adapter.ts
+++ b/lib/adapters/ejs.adapter.ts
@@ -37,7 +37,10 @@ export class EjsAdapter implements TemplateAdapter {
 
         this.precompiledTemplates[templateName] = compile(
           template,
-          get(mailerOptions, 'template.options', {}),
+          {
+            ...get(mailerOptions, 'template.options', {}),
+            filename: templatePath
+          },
         );
       } catch (err) {
         return callback(err);


### PR DESCRIPTION
Ejs needs to know the filename of the compiled file in order for relative includes to work.