### PR TITLE
fix(send-mail-options): change contents to content

### DIFF
--- a/lib/interfaces/send-mail-options.interface.ts
+++ b/lib/interfaces/send-mail-options.interface.ts
@@ -38,7 +38,7 @@ export interface ISendMailOptions extends SendMailOptions {
   template?: string;
   attachments?: {
     filename: string;
-    contents?: any;
+    content?: any;
     path?: string;
     contentType?: string;
     cid?: string;


### PR DESCRIPTION
Here's the fix for #210 

Also please consider changing the Type from `any` to `string | Buffer | ReadStream`. As stated in [nodemailer docs](https://nodemailer.com/message/attachments/).