### PR TITLE
feat(dkim): add dkim optional parameter to send mail options

### DIFF
--- a/lib/interfaces/send-mail-options.interface.ts
+++ b/lib/interfaces/send-mail-options.interface.ts
@@ -1,4 +1,5 @@
 import { SendMailOptions } from 'nodemailer';
+import * as DKIM from 'nodemailer/lib/dkim';
 
 export type TextEncoding = 'quoted-printable' | 'base64';
 export type Headers =
@@ -43,4 +44,5 @@ export interface ISendMailOptions extends SendMailOptions {
     contentType?: string;
     cid?: string;
   }[];
+  dkim?: DKIM.Options;
 }


### PR DESCRIPTION
Hi, 
Based on nodemailer documentation, we should be able to send dkim with a specific message (https://nodemailer.com/dkim/#3-sign-a-specific-message). 
I added an optional parameter in send mail options using DKIM Options from nodemailer. 

That works locally (tested with npm link and our current developing app). 

(I hope I did well with the PR, this is my first time contributing to an OS project, do not hesitate to exchange with me about that)