### PR TITLE
Set a strict definition of whether the path to the template is absolute or relative. Allow the use of subfolders for template files.

### DIFF
--- a/lib/adapters/ejs.adapter.ts
+++ b/lib/adapters/ejs.adapter.ts
@@ -36,9 +36,9 @@ export class EjsAdapter implements TemplateAdapter {
       path.extname(mail.data.template),
     );
     const templateDir =
-      path.dirname(mail.data.template) !== '.'
-        ? path.dirname(mail.data.template)
-        : get(mailerOptions, 'template.dir', '');
+      path.dirname(mail.data.template).startsWith('.')
+        ? get(mailerOptions, 'template.dir', '')
+        : path.dirname(mail.data.template);
     const templatePath = path.join(templateDir, templateName + templateExt);
 
     if (!this.precompiledTemplates[templateName]) {

--- a/lib/adapters/ejs.adapter.ts
+++ b/lib/adapters/ejs.adapter.ts
@@ -36,7 +36,7 @@ export class EjsAdapter implements TemplateAdapter {
       path.extname(mail.data.template),
     );
     const templateDir =
-      path.dirname(mail.data.template).startsWith('.')
+      mail.data.template.startsWith('./')
         ? get(mailerOptions, 'template.dir', '')
         : path.dirname(mail.data.template);
     const templatePath = path.join(templateDir, templateName + templateExt);

--- a/lib/adapters/handlebars.adapter.ts
+++ b/lib/adapters/handlebars.adapter.ts
@@ -36,7 +36,7 @@ export class HandlebarsAdapter implements TemplateAdapter {
       const templateExt = path.extname(template) || '.hbs';
       const templateName = path.basename(template, path.extname(template));
       const templateDir =
-        path.dirname(template).startsWith('.')
+        template.startsWith('./')
           ? get(options, 'dir', '')
           : path.dirname(template);
       const templatePath = path.join(templateDir, templateName + templateExt);

--- a/lib/adapters/handlebars.adapter.ts
+++ b/lib/adapters/handlebars.adapter.ts
@@ -36,9 +36,9 @@ export class HandlebarsAdapter implements TemplateAdapter {
       const templateExt = path.extname(template) || '.hbs';
       const templateName = path.basename(template, path.extname(template));
       const templateDir =
-        path.dirname(template) !== '.'
-          ? path.dirname(template)
-          : get(options, 'dir', '');
+        path.dirname(template).startsWith('.')
+          ? get(options, 'dir', '')
+          : path.dirname(template);
       const templatePath = path.join(templateDir, templateName + templateExt);
 
       if (!this.precompiledTemplates[templateName]) {

--- a/lib/adapters/pug.adapter.ts
+++ b/lib/adapters/pug.adapter.ts
@@ -26,9 +26,9 @@ export class PugAdapter implements TemplateAdapter {
       path.extname(mail.data.template),
     );
     const templateDir =
-      path.dirname(mail.data.template) !== '.'
-        ? path.dirname(mail.data.template)
-        : get(mailerOptions, 'template.dir', '');
+      path.dirname(mail.data.template).startsWith('.')
+        ? get(mailerOptions, 'template.dir', '')
+        : path.dirname(mail.data.template);
     const templatePath = path.join(templateDir, templateName + templateExt);
 
     const options = {

--- a/lib/adapters/pug.adapter.ts
+++ b/lib/adapters/pug.adapter.ts
@@ -26,7 +26,7 @@ export class PugAdapter implements TemplateAdapter {
       path.extname(mail.data.template),
     );
     const templateDir =
-      path.dirname(mail.data.template).startsWith('.')
+      mail.data.template.startsWith('./')
         ? get(mailerOptions, 'template.dir', '')
         : path.dirname(mail.data.template);
     const templatePath = path.join(templateDir, templateName + templateExt);


### PR DESCRIPTION
This PR sets a strict definition of whether the path to the template is absolute or relative.
And it also allows the use of subfolders for template files.

Usage example:
```typescript
.sendMail({
  to: 'test@nestjs.com',
  from: 'noreply@nestjs.com',
  subject: 'Testing Nest Mailermodule with template ✔',
  template: './en/welcome', // The final template path will look like ${mailerconfig.template.dir}/en/welcome.${adapterExt}
  context: {
    code: 'cf1a3f828287',
    username: 'john doe',
  },
})
```