### PR TITLE
fix(adapters): resolving correct templateDir

### DIFF
--- a/lib/adapters/ejs.adapter.ts
+++ b/lib/adapters/ejs.adapter.ts
@@ -37,8 +37,8 @@ export class EjsAdapter implements TemplateAdapter {
     );
     const templateDir =
       mail.data.template.startsWith('./')
-        ? get(mailerOptions, 'template.dir', '')
-        : path.dirname(mail.data.template);
+        ? path.dirname(mail.data.template)
+        : get(mailerOptions, 'template.dir', '')
     const templatePath = path.join(templateDir, templateName + templateExt);
 
     if (!this.precompiledTemplates[templateName]) {

--- a/lib/adapters/handlebars.adapter.ts
+++ b/lib/adapters/handlebars.adapter.ts
@@ -35,10 +35,9 @@ export class HandlebarsAdapter implements TemplateAdapter {
     const precompile = (template: any, callback: any, options: any) => {
       const templateExt = path.extname(template) || '.hbs';
       const templateName = path.basename(template, path.extname(template));
-      const templateDir =
-        template.startsWith('./')
-          ? get(options, 'dir', '')
-          : path.dirname(template);
+      const templateDir = template.startsWith('./')
+        ? path.dirname(template)
+        : get(options, 'dir', '');
       const templatePath = path.join(templateDir, templateName + templateExt);
 
       if (!this.precompiledTemplates[templateName]) {

--- a/lib/adapters/pug.adapter.ts
+++ b/lib/adapters/pug.adapter.ts
@@ -25,10 +25,9 @@ export class PugAdapter implements TemplateAdapter {
       mail.data.template,
       path.extname(mail.data.template),
     );
-    const templateDir =
-      mail.data.template.startsWith('./')
-        ? get(mailerOptions, 'template.dir', '')
-        : path.dirname(mail.data.template);
+    const templateDir = mail.data.template.startsWith('./')
+      ? path.dirname(mail.data.template)
+      : get(mailerOptions, 'template.dir', '');
     const templatePath = path.join(templateDir, templateName + templateExt);
 
     const options = {


### PR DESCRIPTION
The conditional expression which decides if the passed template name is a path or not resolved the template dir in the wrong order. This fix will change the order. As a result if the template name is a path, the templateDir will be resolved from the template name. Elsewhere it will use the default template dir provided by the Module.forRoot

References this [comment](https://github.com/nest-modules/mailer/commit/5301beafcf9e10ff28475076468313a7319c954d#commitcomment-52210085)