### PR TITLE
fix: no error handling for inlineCss

### DIFF
--- a/lib/adapters/ejs.adapter.ts
+++ b/lib/adapters/ejs.adapter.ts
@@ -58,10 +58,12 @@ export class EjsAdapter implements TemplateAdapter {
 
     const render = (html: string) => {
       if (this.config.inlineCssEnabled) {
-        inlineCss(html, this.config.inlineCssOptions).then((html) => {
-          mail.data.html = html;
-          return callback();
-        });
+        inlineCss(html, this.config.inlineCssOptions)
+          .then((html) => {
+            mail.data.html = html;
+            return callback();
+          })
+          .catch(callback);
       } else {
         mail.data.html = html;
         return callback();

--- a/lib/adapters/handlebars.adapter.ts
+++ b/lib/adapters/handlebars.adapter.ts
@@ -96,10 +96,12 @@ export class HandlebarsAdapter implements TemplateAdapter {
     );
 
     if (this.config.inlineCssEnabled) {
-      inlineCss(rendered, this.config.inlineCssOptions).then((html) => {
-        mail.data.html = html;
-        return callback();
-      });
+      inlineCss(rendered, this.config.inlineCssOptions)
+        .then((html) => {
+          mail.data.html = html;
+          return callback();
+        })
+        .catch(callback);
     } else {
       mail.data.html = rendered;
       return callback();

--- a/lib/adapters/pug.adapter.ts
+++ b/lib/adapters/pug.adapter.ts
@@ -41,10 +41,12 @@ export class PugAdapter implements TemplateAdapter {
       }
 
       if (this.config.inlineCssEnabled) {
-        inlineCss(body, this.config.inlineCssOptions).then((html) => {
-          mail.data.html = html;
-          return callback();
-        });
+        inlineCss(body, this.config.inlineCssOptions)
+          .then((html) => {
+            mail.data.html = html;
+            return callback();
+          })
+          .catch(callback);
       } else {
         mail.data.html = body;
         return callback();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,18 +13,8 @@
     "sourceMap": false,
     "outDir": "./dist",
     "rootDir": "./lib",
-    "lib": ["es7"]
+    "lib": ["es7", "DOM"]
   },
-  "include": [
-    "lib/**/*"
-  ],
-  "exclude": [
-    "node_modules", 
-    "**/*.spec.ts"
-  ]
+  "include": ["lib/**/*"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
 }
-
-
-
-
-   


### PR DESCRIPTION
The absence of error handling for `inlineCss` was causing UnhandledPromiseRejection for invalid template CSS.

Example of incorrect template that was causing the issue: https://gist.github.com/lsheva/b882e889191eebec92a290a115f75aa6

Fixes https://github.com/nest-modules/mailer/issues/416

`DOM` was added to libs in `tsconfig.json` due to [issue](https://github.com/axios/axios/issues/4124) with Axios during build.