### PR TITLE
Re-adding attachements object property missing on ISendMailOptions interface

### DIFF
--- a/lib/interfaces/send-mail-options.interface.ts
+++ b/lib/interfaces/send-mail-options.interface.ts
@@ -37,5 +37,15 @@ export interface ISendMailOptions extends SendMailOptions {
   };
   transporterName?: string;
   template?: string;
+  attachments?: {
+    filename: string;
+    content?: any;
+    path?: string;
+    contentType?: string;
+    cid?: string;
+    encoding?:string;
+    contentDisposition?:string;
+    href?:string;
+  }[];
   dkim?: DKIM.Options;
 }


### PR DESCRIPTION
Fixing the issue #731 where the attachments property has disappeard from the ISendMailOptions interface, with no reason from this commit. https://github.com/nest-modules/mailer/commit/08e61f637e022111fcbb9c0239c1b3bfab1549c6#diff-b51ba76cd229c63d55965fb4c3203d2ea7255cf1897c1462b1ea65fd343d828b 