### PR TITLE
feat: Add possibility to specify extra providers

### DIFF
--- a/lib/interfaces/mailer-async-options.interface.ts
+++ b/lib/interfaces/mailer-async-options.interface.ts
@@ -1,5 +1,6 @@
 /** Dependencies **/
 import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
+import { Provider } from "@nestjs/common";
 
 /** Interfaces **/
 import { MailerOptions } from './mailer-options.interface';
@@ -10,4 +11,5 @@ export interface MailerAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
   useClass?: Type<MailerOptionsFactory>;
   useExisting?: Type<MailerOptionsFactory>;
   useFactory?: (...args: any[]) => Promise<MailerOptions> | MailerOptions;
+  extraProviders?: Provider[];
 }

--- a/lib/mailer-core.module.ts
+++ b/lib/mailer-core.module.ts
@@ -49,6 +49,9 @@ export class MailerCoreModule {
 
         /** Services **/
         MailerService,
+        
+        /** Extra providers **/
+        ...(options.extraProviders || []),
       ],
       imports: options.imports,
       exports: [


### PR DESCRIPTION
Useful when the consumers wants to use a provider in the `useFactory` method. Inspired by Nest's `HttpModule` ([code](https://github.com/nestjs/nest/blob/53d88e59523b90191b8e5debf01800e1d8252631/packages/common/http/http.module.ts#L62)).
More info on the issue: https://stackoverflow.com/a/66164772/10878244

Usage example:
```ts
import ...

@Global()
@Module({})
export class AppMailerModule {
  public static registerAsync(options: AppMailerAsyncOptions): DynamicModule {
    const configProvider = this.createConfigProvider(options);

    return {
      module: AppMailerModule,
      imports: [
        MailerModule.forRootAsync({
          imports: options.imports || [],
          inject: [APP_MAILER_OPTIONS],
          extraProviders: [configProvider], // <-- Specify extra providers
          useFactory: async (consumerOptions: AppMailerOptions) => {
            return {
              ...consumerOptions.mailer,
              // <-- Now we can use it to add default options for example
            };
          },
        }),
        ...(options.imports || []),
      ],
      providers: [configProvider, AppMailerService],
      exports: [AppMailerService],
    };
  }
}
```