### PR TITLE
bug fixed for exception handling when precompiling templates with hbs

### DIFF
--- a/lib/adapters/handlebars.adapter.ts
+++ b/lib/adapters/handlebars.adapter.ts
@@ -49,7 +49,8 @@ export class HandlebarsAdapter implements TemplateAdapter {
             get(options, 'options', {}),
           );
         } catch (err) {
-          return callback(err);
+          callback(err);
+          return null;
         }
       }
 
@@ -61,12 +62,16 @@ export class HandlebarsAdapter implements TemplateAdapter {
       };
     };
 
-    const { templateName } = precompile(
+    const precompiledData = precompile(
       mail.data.template,
       callback,
       mailerOptions.template,
     );
+    if (precompiledData === null) {
+      return;
+    }
 
+    const { templateName } = precompiledData;
     const runtimeOptions = get(mailerOptions, 'options', {
       partials: false,
       data: {},
@@ -77,11 +82,16 @@ export class HandlebarsAdapter implements TemplateAdapter {
         path.join(runtimeOptions.partials.dir, '**', '*.hbs'),
       );
       files.forEach((file) => {
-        const { templateName, templatePath } = precompile(
+        const precompiledData = precompile(
           file,
           () => {},
           runtimeOptions.partials,
         );
+        if (precompiledData === null) {
+          return;
+        }
+
+        const { templateName, templatePath } = precompiledData;
         const templateDir = path.relative(
           runtimeOptions.partials.dir,
           path.dirname(templatePath),


### PR DESCRIPTION
Hi, thank you for developing to use nodemailer in nestjs.
I pushed a PR for bug fix that occur when not exist template file in handlebars precompile.

---

If you look at the code, you can see that if an exception is raised (etc. **ENOENT: no such file or directory, open '...'**) inside precompile(), the function end at the same time as passing the exception to the callback through line 52. 

As a result, undefined is returned in lines 64 and 80, and the desired value cannot be obtained through the spread operator, and at the same time, the following exception occurs. **[TypeError: Cannot destructure property 'templateName' of 'precompile(...)' as it is undefined.]**

However, the exception that occurred inside precompile() was already handled by callback(err) through line 52, and the exception that occurred in lines 64 and 80 was not handled, exit code 1 occurred and the node was down. (Unfortunately, I didn't see a way to handle it from the outside.)

The change of the PR is that if an exception occurs at the time of template precompiling, the exception is passed through callback() and then the compile process is stopped, and in the case of partial, it is modified to skip the partial.

----

This is my first PR in my life, so please forgive me if there are any mistakes, and if you tell me, I will correct it.