### PR TITLE
Fixed Handlebars/EJS template caching

### DIFF
--- a/lib/adapters/ejs.adapter.ts
+++ b/lib/adapters/ejs.adapter.ts
@@ -31,15 +31,14 @@ export class EjsAdapter implements TemplateAdapter {
 
   public compile(mail: any, callback: any, mailerOptions: MailerOptions): void {
     const { context, template } = mail.data;
+    const templateBaseDir = get(mailerOptions, 'template.dir', '');
     const templateExt = path.extname(template) || '.ejs';
-    const templateName = path.basename(template, path.extname(template));
+    let templateName = path.basename(template, path.extname(template));
     const templateDir = path.isAbsolute(template)
       ? path.dirname(template)
-      : path.join(
-          get(mailerOptions, 'template.dir', ''),
-          path.dirname(template),
-        );
+      : path.join(templateBaseDir, path.dirname(template));
     const templatePath = path.join(templateDir, templateName + templateExt);
+    templateName = path.relative(templateBaseDir, templatePath).replace(templateExt, '');
 
     if (!this.precompiledTemplates[templateName]) {
       try {

--- a/lib/adapters/handlebars.adapter.ts
+++ b/lib/adapters/handlebars.adapter.ts
@@ -33,12 +33,14 @@ export class HandlebarsAdapter implements TemplateAdapter {
 
   public compile(mail: any, callback: any, mailerOptions: MailerOptions): void {
     const precompile = (template: any, callback: any, options: any) => {
+      const templateBaseDir = get(options, 'dir', '');
       const templateExt = path.extname(template) || '.hbs';
-      const templateName = path.basename(template, path.extname(template));
+      let templateName = path.basename(template, path.extname(template));
       const templateDir = path.isAbsolute(template)
         ? path.dirname(template)
-        : path.join(get(options, 'dir', ''), path.dirname(template));
+        : path.join(templateBaseDir, path.dirname(template));
       const templatePath = path.join(templateDir, templateName + templateExt);
+      templateName = path.relative(templateBaseDir, templatePath).replace(templateExt, '');
 
       if (!this.precompiledTemplates[templateName]) {
         try {


### PR DESCRIPTION
When organizing templates in subfolders, files with the same name are not rendered correctly. This is because Handlebars and EJS adapters precompile the templates and put them into a lookup object. However, as only the template name is used as the key, files from different subfolders cannot be distinguished. E.g.:
```
/templates
  /en
    myTemplate.hbs
  /es
    myTemplate.hbs
```
Using `en/myTemplate` renders the correct English file, any follow up calls use the cached English file as well, even if we pass `es/myTemplate`. As a workaround we can use a prefix to make file names unique, as mentioned in [#684](https://github.com/nest-modules/mailer/issues/684#issuecomment-926523084), but imho it's better to have mailer support this natively.

This pull request changes the keys of the lookup objects to the full relative paths, e.g. `en/myTemplate` instead of only `myTemplate` to fix the issue.