### PR TITLE
Bugfix/fixes partial not found error on Windows

### DIFF
--- a/lib/adapters/handlebars.adapter.ts
+++ b/lib/adapters/handlebars.adapter.ts
@@ -75,9 +75,10 @@ export class HandlebarsAdapter implements TemplateAdapter {
     });
 
     if (runtimeOptions.partials) {
-      const files = glob.sync(
-        path.join(runtimeOptions.partials.dir, '**', '*.hbs'),
-      );
+      const partialPath = path.join(runtimeOptions.partials.dir, '**', '*.hbs').replace(/\\/g,'/');
+
+      const files = glob.sync(partialPath);
+      
       files.forEach((file) => {
         const { templateName, templatePath } = precompile(
           file,


### PR DESCRIPTION
There are a few issues (https://github.com/nest-modules/mailer/issues/906 and https://github.com/nest-modules/mailer/issues/825)  related to partials not working in Windows due to glob. 

I noticed no one had created a PR  for it yet, so I took the solution from @damdafayton on https://github.com/nest-modules/mailer/issues/906 and created one. Not sure if this is the best solution (maybe there is a better way to do it?) but I can confirm this does fix it when running in Windows.