### PR TITLE
fix: use namespace import for mjml in adapter

### DIFF
--- a/lib/adapters/mjml.adapter.ts
+++ b/lib/adapters/mjml.adapter.ts
@@ -5,7 +5,7 @@ import { TemplateAdapterConfig } from '../interfaces/template-adapter-config.int
 import { PugAdapter } from './pug.adapter';
 import { TemplateAdapter } from '../interfaces/template-adapter.interface';
 import { MailerOptions } from '../interfaces/mailer-options.interface';
-import mjml2html from 'mjml';
+import * as mjml2html from 'mjml';
 
 export class MjmlAdapter implements TemplateAdapter {
   private engine: TemplateAdapter | null;


### PR DESCRIPTION
Closes #982

**Description**:
When using the MjmlAdapter from the mailer module the following error is thrown when the compile function is invoked:

TypeError: (0 , mjml_1.default) is not a function

**Suggested Solution**:
Use a namespace import for the `mjml2html` function.