### PR TITLE
Update ISendMailOptions type

### DIFF
--- a/lib/interfaces/send-mail-options.interface.ts
+++ b/lib/interfaces/send-mail-options.interface.ts
@@ -20,7 +20,7 @@ export interface ISendMailOptions extends SendMailOptions {
   to?: string | Address | Array<string | Address>;
   cc?: string | Address | Array<string | Address>;
   bcc?: string | Address | Array<string | Address>;
-  replyTo?: string | Address;
+  replyTo?: string | Address | Array<string | Address>;
   inReplyTo?: string | Address;
   from?: string | Address;
   subject?: string;


### PR DESCRIPTION
In this PR, I updated the type for sending email to allow more than one address in the replyTo field. 

This was added with Nodemailer v6.7.8 (Reference: https://github.com/adonisjs/mail/pull/82)