### PR TITLE
chore: Replace `css-inline` with `@css-inline/css-inline`

### DIFF
--- a/docs/mailer.md
+++ b/docs/mailer.md
@@ -307,7 +307,7 @@ Just provide config object in constructor.
 ```typescript
 new HandlebarsAdapter(/* helpers */ undefined, {
   inlineCssEnabled: true,
-  /** See https://www.npmjs.com/package/css-inline#configuration */
+  /** See https://www.npmjs.com/package/@css-inline/css-inline#configuration */
   inlineCssOptions: {},
 });
 

--- a/lib/adapters/ejs.adapter.ts
+++ b/lib/adapters/ejs.adapter.ts
@@ -8,7 +8,7 @@ import {
 import { get } from 'lodash';
 import * as fs from 'fs';
 import * as path from 'path';
-import { inline } from 'css-inline';
+import { inline } from '@css-inline/css-inline';
 
 /** Interfaces **/
 import { MailerOptions } from '../interfaces/mailer-options.interface';

--- a/lib/adapters/handlebars.adapter.ts
+++ b/lib/adapters/handlebars.adapter.ts
@@ -2,7 +2,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as handlebars from 'handlebars';
-import { inline } from 'css-inline';
+import { inline } from '@css-inline/css-inline';
 import * as glob from 'glob';
 import { get } from 'lodash';
 import { HelperDeclareSpec } from 'handlebars';

--- a/lib/adapters/pug.adapter.ts
+++ b/lib/adapters/pug.adapter.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 import { get } from 'lodash';
 import { renderFile } from 'pug';
-import { inline } from 'css-inline';
+import { inline } from '@css-inline/css-inline';
 
 /** Interfaces **/
 import { MailerOptions } from '../interfaces/mailer-options.interface';

--- a/lib/interfaces/template-adapter-config.interface.ts
+++ b/lib/interfaces/template-adapter-config.interface.ts
@@ -1,6 +1,6 @@
-import { InlineOptions } from 'css-inline';
+import { Options } from '@css-inline/css-inline';
 
 export interface TemplateAdapterConfig {
-  inlineCssOptions?: InlineOptions;
+  inlineCssOptions?: Options;
   inlineCssEnabled?: boolean;
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     ]
   },
   "dependencies": {
-    "css-inline": "0.11.2",
+    "@css-inline/css-inline": "0.12.1",
     "glob": "10.3.10",
     "mjml": "4.14.1",
     "preview-email": "3.0.19"

--- a/sample/02-custom-template-adapter/README.md
+++ b/sample/02-custom-template-adapter/README.md
@@ -21,7 +21,7 @@ Create your custom adapter class and be sure to implements `TemplateAdapter` int
 ```typescript
 // adapters/twing.adapter.ts
 import { MailerOptions, TemplateAdapter } from '@nestjs-modules/mailer';
-import { inline } from 'css-inline';
+import { inline } from '@css-inline/css-inline';
 import * as path from 'path';
 import { TwingEnvironment, TwingLoaderFilesystem, TwingTemplate } from 'twing';
 

--- a/sample/02-custom-template-adapter/src/adapters/twing.adapter.ts
+++ b/sample/02-custom-template-adapter/src/adapters/twing.adapter.ts
@@ -1,5 +1,5 @@
 import { MailerOptions, TemplateAdapter } from '@nestjs-modules/mailer';
-import { inline } from 'css-inline';
+import { inline } from '@css-inline/css-inline';
 import * as path from 'path';
 import { TwingEnvironment, TwingLoaderFilesystem, TwingTemplate } from 'twing';
 


### PR DESCRIPTION
I've recently added `napi.rs` bindings to `css-inline` and now it is published under a different name. There is also a WASM module available under `@css-inline/css-inline-wasm` which is more or less the same as the package used here (smaller in size though).

**NOTE**: The option names are now camel-cased.