### PR TITLE
Fix bug by using nodemailer-sendgrid

### DIFF
--- a/lib/interfaces/mailer-options.interface.ts
+++ b/lib/interfaces/mailer-options.interface.ts
@@ -60,4 +60,5 @@ export interface MailerOptions {
          */
         open: boolean | { wait: boolean; app: string | string[] };
       }>;
+  verifyTransporters?: boolean;
 }

--- a/lib/mailer.service.ts
+++ b/lib/mailer.service.ts
@@ -90,7 +90,7 @@ export class MailerService {
       Object.keys(mailerOptions.transports).forEach((name) => {
         const transporter = this.transportFactory.createTransport(this.mailerOptions.transports![name])
         this.transporters.set(name, transporter);
-        this.verifyTransporter(transporter, name);
+        if (mailerOptions.verifyTransporters) this.verifyTransporter(transporter, name);
         this.initTemplateAdapter(this.templateAdapter, transporter);
       });
     }
@@ -98,13 +98,14 @@ export class MailerService {
     /** Transporter setup **/
     if (mailerOptions.transport) {
       this.transporter = this.transportFactory.createTransport();
-      this.verifyTransporter(this.transporter);
+      if (mailerOptions.verifyTransporters) this.verifyTransporter(this.transporter);
       this.initTemplateAdapter(this.templateAdapter, this.transporter);
     }
   }
 
   private verifyTransporter(transporter: Transporter, name?: string): void {
     const transporterName = name ? ` '${name}'` : '';
+    if (!transporter.verify) return;
     transporter.verify()
       .then(() => this.mailerLogger.debug(`Transporter${transporterName} is ready`))
       .catch((error) => this.mailerLogger.error(`Error occurred while verifying the transporter${transporterName}: ${error.message}`));
@@ -112,7 +113,10 @@ export class MailerService {
 
   public async verifyAllTransporters() {
     const transporters = [...this.transporters.values(), this.transporter];
-    const transportersVerified = await Promise.all(transporters.map(transporter => transporter.verify().catch(() => false)));
+    const transportersVerified = await Promise.all(transporters.map(transporter => {
+      if (!transporter.verify) return true; // Can't verify with nodemailer-sendgrid, so assume it's verified
+      transporter.verify().catch(() => false);
+    }));
     return transportersVerified.every(verified => verified);
   }
 


### PR DESCRIPTION
I fixed the bug that occurred with nodemailer-sendgrid. I'm sorry, I had indeed run npm run test, but apart from connection error messages, I didn't notice any crashes, and I didn't test it with nodemailer-sendgrid.

So, I made it so that my function only executes if we specify an option 'verifyTransporters', which is false by default. This way, it won't be blocking. I also added an undefined check on the transporter.verify to avoid crashing.