### PR TITLE
refactor: Handle optional transporter.verify gracefully

### DIFF
--- a/lib/mailer.service.ts
+++ b/lib/mailer.service.ts
@@ -105,9 +105,10 @@ export class MailerService {
 
   private verifyTransporter(transporter: Transporter, name?: string): void {
     const transporterName = name ? ` '${name}'` : '';
-    transporter.verify()
-      .then(() => this.mailerLogger.debug(`Transporter${transporterName} is ready`))
-      .catch((error) => this.mailerLogger.error(`Error occurred while verifying the transporter${transporterName}: ${error.message}`));
+    !transporter.verify ? this.mailerLogger.debug(`Transporter${transporterName} is ready`) :
+      transporter.verify()
+        .then(() => this.mailerLogger.debug(`Transporter${transporterName} is ready`))
+        .catch((error) => this.mailerLogger.error(`Error occurred while verifying the transporter${transporterName}: ${error.message}`));
   }
 
   public async verifyAllTransporters() {


### PR DESCRIPTION
This pull request addresses an issue within the @nestjs-modules/mailer library, where the transport.verify function is executed even though it's marked as optional in the nodemailer typings. This causes failures, especially with transport configurations lacking the verify function, such as streamTransport.

## Related Issues
This PR is a proposed fix to #1144. 