### PR TITLE
Fix mail transporter verification

### DIFF
--- a/lib/mailer.service.ts
+++ b/lib/mailer.service.ts
@@ -105,14 +105,14 @@ export class MailerService {
 
   private verifyTransporter(transporter: Transporter, name?: string): void {
     const transporterName = name ? ` '${name}'` : '';
-    transporter.verify()
+    Promise.resolve(transporter.verify())
       .then(() => this.mailerLogger.debug(`Transporter${transporterName} is ready`))
       .catch((error) => this.mailerLogger.error(`Error occurred while verifying the transporter${transporterName}: ${error.message}`));
   }
 
   public async verifyAllTransporters() {
     const transporters = [...this.transporters.values(), this.transporter];
-    const transportersVerified = await Promise.all(transporters.map(transporter => transporter.verify().catch(() => false)));
+    const transportersVerified = await Promise.all(transporters.map(transporter => Promise.resolve(transporter.verify()).then(() => true).catch(() => false)));
     return transportersVerified.every(verified => verified);
   }
 


### PR DESCRIPTION
In case of json transporters, or any transporter which does not implement the `verify` function, the Mailer class inside nodemailer overwrites it with a generic non-async function, which just returns `false`. This leads to the following error:

```
2024-04-03 23:25:19 TypeError: transporter.verify(...).then is not a function
2024-04-03 23:25:19     at MailerService.verifyTransporter (/app/node_modules/@nestjs-modules/mailer/dist/mailer.service.js:67:14)
2024-04-03 23:25:19     at new MailerService (/app/node_modules/@nestjs-modules/mailer/dist/mailer.service.js:60:18)
2024-04-03 23:25:19     at Injector.instantiateClass (/app/node_modules/@nestjs/core/injector/injector.js:365:19)
2024-04-03 23:25:19     at callback (/app/node_modules/@nestjs/core/injector/injector.js:65:45)
2024-04-03 23:25:19     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2024-04-03 23:25:19     at async Injector.resolveConstructorParams (/app/node_modules/@nestjs/core/injector/injector.js:144:24)
2024-04-03 23:25:19     at async Injector.loadInstance (/app/node_modules/@nestjs/core/injector/injector.js:70:13)
2024-04-03 23:25:19     at async Injector.loadProvider (/app/node_modules/@nestjs/core/injector/injector.js:97:9)
2024-04-03 23:25:19     at async /app/node_modules/@nestjs/core/injector/instance-loader.js:56:13
2024-04-03 23:25:19     at async Promise.all (index 4)
```

By wrapping the call to `transporter.verify()` inside `Promise.resolve` we can safely proceed with the existing flow.

See nodemailer source here: https://github.com/nodemailer/nodemailer/blob/fa63b52d8a03da49a60c00b6c073a0d77aeababb/lib/mailer/index.js#L95-L115