### PR TITLE
Move mjml to optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ npm install --save handlebars
 npm install --save pug
 #or
 npm install --save ejs
+#or
+npm install --save mjml
 ```
 
 #### with yarn
@@ -43,6 +45,8 @@ yarn add handlebars
 yarn add pug
 #or
 yarn add ejs
+#or
+yarn add mjml
 ```
 
 ### Documentation

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "@css-inline/css-inline": "0.13.0",
     "glob": "10.3.10",
-    "mjml": "4.15.3",
     "preview-email": "3.0.19"
   },
   "optionalDependencies": {
@@ -63,6 +62,7 @@
     "@types/pug": "^2.0.10",
     "ejs": "^3.1.9",
     "handlebars": "^4.7.8",
+    "mjml": "^4.15.3",
     "pug": "^3.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ dependencies:
   glob:
     specifier: 10.3.10
     version: 10.3.10
-  mjml:
-    specifier: 4.15.3
-    version: 4.15.3
   preview-email:
     specifier: 3.0.19
     version: 3.0.19
@@ -31,6 +28,9 @@ optionalDependencies:
   handlebars:
     specifier: ^4.7.8
     version: 4.7.8
+  mjml:
+    specifier: ^4.15.3
+    version: 4.15.3
   pug:
     specifier: ^3.0.2
     version: 3.0.2
@@ -5744,6 +5744,7 @@ packages:
     transitivePeerDependencies:
       - encoding
     dev: false
+    optional: true
 
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}


### PR DESCRIPTION
At the moment @nestjs-modules/mailer suffers from High severity vulnerablity https://github.com/advisories/GHSA-pfq8-rq6v-vf5m. The vulnerable, not well-maintained package html-minifier is a depenency of mjml package.
This package is used only for adapter implementation, and it is not mandatory to have it installed. 

At the moment, there is no fix for mjml or html-minifier. Moving mjml into optional dependencies allows to install @nestjs-modules/mailer using any other adapter, without suffering audit failure in a short term, until the vulnerability is fixed