### PR TITLE
fix: Update css-inline dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ]
   },
   "dependencies": {
-    "@css-inline/css-inline": "0.14.1",
+    "@css-inline/css-inline": "0.14.3",
     "glob": "10.3.12"
   },
   "optionalDependencies": {


### PR DESCRIPTION
update css-inline to include the new arch (linux-arm64-gnu) supported in 0.14.3.