### PR TITLE
chore(deps): add missing lodash dependency for mailer

### DIFF
--- a/packages/mailer/package.json
+++ b/packages/mailer/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@css-inline/css-inline": "0.20.0",
     "glob": "13.0.6",
+    "lodash": ">=4.18.1",
     "tslib": "^2.8.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
fixed a dependency error with the mailer package

version:
`"@nestjs-modules/mailer": "2.3.6"`

package manager:
`pnpm@11.3.0`

engine:
`node 24.7.0`

```
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
Error: Cannot find module 'lodash'
Require stack:
- /app/node_modules/.pnpm/@nestjs-modules+mailer@2.3.6_240b968bfbda69b006c3412369b74cfa/node_modules/@nestjs-modules/mailer/dist/mailer.service.js
- /app/node_modules/.pnpm/@nestjs-modules+mailer@2.3.6_240b968bfbda69b006c3412369b74cfa/node_modules/@nestjs-modules/mailer/dist/health/mailer.health-indicator.js
- /app/node_modules/.pnpm/@nestjs-modules+mailer@2.3.6_240b968bfbda69b006c3412369b74cfa/node_modules/@nestjs-modules/mailer/dist/index.js
- /app/dist/src/core/messaging/messaging.module.js
- /app/dist/src/apps/api/api.module.js
- /app/dist/src/apps/api/run-api.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1410:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1051:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1056:22)
    at Module._load (node:internal/modules/cjs/loader:1219:37)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:238:24)
    at Module.<anonymous> (node:internal/modules/cjs/loader:1493:12)
    at Module.patchedRequire (/app/node_modules/.pnpm/require-in-the-middle@8.0.1/node_modules/require-in-the-middle/index.js:186:34)
    at Hook._require.Module.require (/app/node_modules/.pnpm/require-in-the-middle@8.0.1/node_modules/require-in-the-middle/index.js:134:27)
    at Module.patchedRequire (/app/node_modules/.pnpm/require-in-the-middle@8.0.1/node_modules/require-in-the-middle/index.js:186:34)
```

It looks like `lodash` is used by the package at runtime but is not declared in `packages/mailer/package.json` dependencies.

