### PR TITLE
fix(mailer): mjml v5 promise handling, queue global option, export TransportType

### DIFF
--- a/.changeset/fix-mjml-queue-global-transporttype.md
+++ b/.changeset/fix-mjml-queue-global-transporttype.md
@@ -1,0 +1,15 @@
+---
+'@nestjs-modules/mailer': patch
+---
+
+Fix several issues in the mailer package:
+
+- **MjmlAdapter**: handle the Promise returned by `mjml2html` in mjml v5+, so
+  rendered HTML is no longer `undefined` (#1312). The adapter now also
+  propagates errors from the inner engine.
+- **MailerQueueModule**: support a `global` option in both `register` and
+  `registerAsync`, allowing `MailerQueueService` to be injected across the
+  application without re-importing the module (#1311).
+- **TransportType**: re-export `TransportType` from the package entry point so
+  custom transports can type their `getTransport()` return value without deep
+  imports (#1309).

--- a/apps/website/docs/queue.md
+++ b/apps/website/docs/queue.md
@@ -26,6 +26,9 @@ import { MailerModule, MailerQueueModule } from '@nestjs-modules/mailer';
       transport: { host: 'smtp.example.com', port: 587 },
     }),
     MailerQueueModule.register({
+      // Set `global: true` so `MailerQueueService` can be injected in any
+      // feature module without re-importing `MailerQueueModule`.
+      global: true,
       connection: {
         host: 'localhost',
         port: 6379,

--- a/packages/mailer/lib/adapters/mjml.adapter.spec.ts
+++ b/packages/mailer/lib/adapters/mjml.adapter.spec.ts
@@ -4,13 +4,16 @@ import { EjsAdapter } from './ejs.adapter';
 import { HandlebarsAdapter } from './handlebars.adapter';
 import { PugAdapter } from './pug.adapter';
 
-// Mock mjml since v5 alpha uses prettier which requires ESM dynamic imports
+// Mock mjml since v5 alpha uses prettier which requires ESM dynamic imports.
+// mjml v5+ returns a Promise from mjml2html (see issue #1312), so the mock
+// resolves asynchronously to mirror real-world behavior.
 jest.mock('mjml', () => {
   return {
     __esModule: true,
-    default: (mjmlContent: string) => ({
-      html: `<html><body>${mjmlContent}</body></html>`,
-    }),
+    default: (mjmlContent: string) =>
+      Promise.resolve({
+        html: `<html><body>${mjmlContent}</body></html>`,
+      }),
   };
 });
 
@@ -80,6 +83,27 @@ describe('MjmlAdapter', () => {
       () => {
         expect(mail.data.html).toContain('Hello');
         expect(mail.data.html).toContain('<html>');
+        done();
+      },
+      { transport: { host: 'localhost', port: 25 } },
+    );
+  });
+
+  it('should propagate errors raised by the inner engine', (done) => {
+    const failingEngine: TemplateAdapter = {
+      compile(_mail: any, callback: any, _options: MailerOptions) {
+        callback(new Error('engine failure'));
+      },
+    };
+
+    const adapter = new MjmlAdapter(failingEngine);
+    const mail = { data: { html: undefined as string | undefined } };
+
+    adapter.compile(
+      mail,
+      (err: any) => {
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe('engine failure');
         done();
       },
       { transport: { host: 'localhost', port: 25 } },

--- a/packages/mailer/lib/adapters/mjml.adapter.ts
+++ b/packages/mailer/lib/adapters/mjml.adapter.ts
@@ -38,9 +38,20 @@ export class MjmlAdapter implements TemplateAdapter {
   public compile(mail: any, callback: any, mailerOptions: MailerOptions): void {
     this?.engine?.compile(
       mail,
-      () => {
-        mail.data.html = mjml2html(mail.data.html).html;
-        callback();
+      (err?: any) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        // mjml v5+ returns a Promise from mjml2html, while v4 returns the
+        // result synchronously. Promise.resolve handles both transparently.
+        Promise.resolve(mjml2html(mail.data.html))
+          .then((result) => {
+            mail.data.html = result.html;
+            callback();
+          })
+          .catch((error) => callback(error));
       },
       mailerOptions,
     );

--- a/packages/mailer/lib/index.ts
+++ b/packages/mailer/lib/index.ts
@@ -24,6 +24,7 @@ export {
   MailerOptions,
   MailerPlugin,
   RateLimitOptions,
+  TransportType,
 } from './interfaces/mailer-options.interface';
 export { MailerOptionsFactory } from './interfaces/mailer-options-factory.interface';
 export { MailerTransportFactory } from './interfaces/mailer-transport-factory.interface';

--- a/packages/mailer/lib/interfaces/queue-options.interface.ts
+++ b/packages/mailer/lib/interfaces/queue-options.interface.ts
@@ -32,4 +32,11 @@ export interface MailerQueueOptions {
 
   /** Queue name (default: 'mailer') */
   queueName?: string;
+
+  /**
+   * Register the module globally so `MailerQueueService` is available across
+   * the whole application without re-importing `MailerQueueModule`
+   * (default: false).
+   */
+  global?: boolean;
 }

--- a/packages/mailer/lib/mailer-queue.module.spec.ts
+++ b/packages/mailer/lib/mailer-queue.module.spec.ts
@@ -1,0 +1,42 @@
+import { MailerQueueOptions } from './interfaces/queue-options.interface';
+import { MailerQueueModule } from './mailer-queue.module';
+import { MailerQueueService } from './mailer-queue.service';
+
+const baseOptions: MailerQueueOptions = {
+  connection: { host: 'localhost', port: 6379 },
+};
+
+describe('MailerQueueModule', () => {
+  describe('register', () => {
+    it('should not be global by default', () => {
+      const dynamicModule = MailerQueueModule.register(baseOptions);
+      expect(dynamicModule.global).toBe(false);
+      expect(dynamicModule.exports).toContain(MailerQueueService);
+    });
+
+    it('should be global when global: true is passed (issue #1311)', () => {
+      const dynamicModule = MailerQueueModule.register({
+        ...baseOptions,
+        global: true,
+      });
+      expect(dynamicModule.global).toBe(true);
+    });
+  });
+
+  describe('registerAsync', () => {
+    it('should not be global by default', () => {
+      const dynamicModule = MailerQueueModule.registerAsync({
+        useFactory: () => baseOptions,
+      });
+      expect(dynamicModule.global).toBe(false);
+    });
+
+    it('should be global when global: true is passed (issue #1311)', () => {
+      const dynamicModule = MailerQueueModule.registerAsync({
+        global: true,
+        useFactory: () => baseOptions,
+      });
+      expect(dynamicModule.global).toBe(true);
+    });
+  });
+});

--- a/packages/mailer/lib/mailer-queue.module.ts
+++ b/packages/mailer/lib/mailer-queue.module.ts
@@ -33,6 +33,7 @@ export class MailerQueueModule {
 
     return {
       module: MailerQueueModule,
+      global: options.global ?? false,
       providers: [optionsProvider, MailerQueueService, MailerQueueProcessor],
       exports: [MailerQueueService],
     };
@@ -41,6 +42,7 @@ export class MailerQueueModule {
   static registerAsync(options: {
     imports?: any[];
     inject?: any[];
+    global?: boolean;
     useFactory: (
       ...args: any[]
     ) => Promise<MailerQueueOptions> | MailerQueueOptions;
@@ -53,6 +55,7 @@ export class MailerQueueModule {
 
     return {
       module: MailerQueueModule,
+      global: options.global ?? false,
       imports: options.imports || [],
       providers: [optionsProvider, MailerQueueService, MailerQueueProcessor],
       exports: [MailerQueueService],


### PR DESCRIPTION
## Summary

Resolves three open issues in the `@nestjs-modules/mailer` package.

### #1312 — MjmlAdapter doesn't work with latest version of mjml
`mjml2html` returns a **Promise** in mjml v5+, so `mjml2html(html).html` evaluated to `undefined`. The adapter now resolves the value (works for both v4 sync and v5 async returns) and propagates inner-engine errors.

### #1311 — MailerQueueModule.register doesn't support global
Added a `global` option to both `register` and `registerAsync`, so `MailerQueueService` can be injected across the app without re-importing the module (no more `Object.assign(..., { global: true })` workaround). Docs updated.

### #1309 — Export `TransportType` from the main entry point
`TransportType` is now re-exported from the package root, so custom transports can type `getTransport(): TransportType` without deep imports. (Overlaps with #1310, which proposed the same one-line change.)

## Testing
- New regression tests: mjml Promise handling + error propagation, and queue `global` option for `register`/`registerAsync`.
- Full package suite: **76 tests passing**.
- `tsc` build passes; verified `TransportType` appears in `dist/index.d.ts`.
- Functional check against **real mjml v5**: adapter now renders a valid HTML document instead of `undefined`.

Closes #1312
Closes #1311
Closes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)